### PR TITLE
feat: add TypeScript/Bun bookshelf implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ A CRUD bookshelf app built in every language. Same API, same database, different
 babel-shelf/
 ├── db/                  # Shared Postgres schema
 │   └── init.sql
-├── go-bookshelf/        # Go implementation
-├── docker-compose.yml   # Orchestrates app + Postgres
+├── go-bookshelf/        # Go (port 8080)
+├── ts-bookshelf/        # TypeScript/Bun (port 8081)
+├── docker-compose.yml   # Orchestrates apps + Postgres
 └── README.md
 ```
 
-Each language gets its own directory (`<lang>-bookshelf/`) with a Dockerfile and devcontainer config. They all share the same Postgres database and expose the same REST API on port 8080.
+Each language gets its own directory (`<lang>-bookshelf/`) with a Dockerfile and devcontainer config. They all share the same Postgres database and expose the same REST API.
 
 ## API
 
@@ -44,19 +45,26 @@ Status must be one of: `want to read`, `reading`, `finished`.
 docker compose up --build
 ```
 
-The API is available at `http://localhost:8080`.
+| Implementation | URL |
+|---------------|-----|
+| Go | `http://localhost:8080` |
+| TypeScript | `http://localhost:8081` |
 
 ## Testing
 
 Tests are integration tests that hit a real Postgres database (no mocks).
 
 ```bash
-# From inside the Go devcontainer or with Go installed:
+# Go — from inside devcontainer or with Go installed:
 cd go-bookshelf
 DATABASE_URL="postgres://shelf:shelf@db:5432/bookshelf?sslmode=disable" go test -v
+
+# TypeScript — from inside devcontainer or with Bun installed:
+cd ts-bookshelf
+DATABASE_URL="postgres://shelf:shelf@db:5432/bookshelf?sslmode=disable" bun test
 ```
 
 ## Implementations
 
 - [x] Go
-- [ ] TypeScript
+- [x] TypeScript (Bun + Hono + pg)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,5 +28,14 @@ services:
       db:
         condition: service_healthy
 
+  ts-bookshelf:
+    build: ./ts-bookshelf
+    ports:
+      - "8081:8081"
+    environment:
+      DATABASE_URL: postgres://shelf:shelf@db:5432/bookshelf?sslmode=disable
+    depends_on:
+      db:
+        condition: service_healthy
 volumes:
   pgdata:

--- a/ts-bookshelf/.devcontainer/devcontainer.json
+++ b/ts-bookshelf/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "TS Bookshelf",
+  "image": "oven/bun:1",
+  "customizations": {
+    "vscode": {
+      "extensions": ["oven.bun-vscode"]
+    }
+  }
+}

--- a/ts-bookshelf/.devcontainer/devcontainer.json
+++ b/ts-bookshelf/.devcontainer/devcontainer.json
@@ -1,9 +1,12 @@
 {
   "name": "TS Bookshelf",
   "image": "oven/bun:1",
+  "postCreateCommand": "bun install",
   "customizations": {
     "vscode": {
-      "extensions": ["oven.bun-vscode"]
+      "extensions": [
+        "oven.bun-vscode"
+      ]
     }
   }
 }

--- a/ts-bookshelf/.gitignore
+++ b/ts-bookshelf/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/ts-bookshelf/Dockerfile
+++ b/ts-bookshelf/Dockerfile
@@ -1,0 +1,12 @@
+FROM oven/bun:1-alpine
+
+WORKDIR /app
+
+COPY package.json bun.lockb ./
+RUN bun install --frozen-lockfile
+
+COPY . .
+
+EXPOSE 8081
+
+CMD ["bun", "run", "src/index.ts"]

--- a/ts-bookshelf/Dockerfile
+++ b/ts-bookshelf/Dockerfile
@@ -2,7 +2,7 @@ FROM oven/bun:1-alpine
 
 WORKDIR /app
 
-COPY package.json bun.lockb ./
+COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 
 COPY . .

--- a/ts-bookshelf/bun.lock
+++ b/ts-bookshelf/bun.lock
@@ -1,0 +1,56 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "ts-bookshelf",
+      "dependencies": {
+        "hono": "^4",
+        "pg": "^8",
+      },
+      "devDependencies": {
+        "@types/pg": "^8",
+        "bun-types": "latest",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@types/pg": ["@types/pg@8.18.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
+
+    "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.3.0", "", {}, "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="],
+
+    "pg-connection-string": ["pg-connection-string@2.12.0", "", {}, "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.13.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA=="],
+
+    "pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+  }
+}

--- a/ts-bookshelf/package.json
+++ b/ts-bookshelf/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ts-bookshelf",
+  "version": "1.0.0",
+  "dependencies": {
+    "hono": "^4",
+    "pg": "^8"
+  },
+  "devDependencies": {
+    "@types/pg": "^8",
+    "bun-types": "latest"
+  },
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "test": "bun test"
+  }
+}

--- a/ts-bookshelf/src/db.ts
+++ b/ts-bookshelf/src/db.ts
@@ -2,66 +2,44 @@
 // the results into TypeScript objects. All database queries live here.
 // Equivalent of db.go in Go.
 
-// ── imports ──
-// Pool from pg — manages database connections
-// Book from models — the type we return
-
 import {Pool} from "pg"
 import {Book} from './models'
 
-// ── pool ──
 // shared database connection — equivalent of Go's `var db *sql.DB`
-// why export? TS files are isolated — index.ts imports pool to set it up,
-// after that only db.ts touches it.
-
 export let pool: Pool
 
-// setPool — lets index.ts and tests assign the pool from outside
-// why not just `export let pool` and reassign it from another file?
-// ES modules give you a copy of the reference, not direct access to the original.
-// reassigning from the importing file only updates your copy — db.ts's pool stays undefined.
-// setter function writes to the original variable inside db.ts.
+// lets index.ts and tests assign the pool from outside
+// can't just export and reassign — ES modules give you a copy, not the original.
+// setter writes to the actual variable inside db.ts.
 export function setPool(p: Pool) { pool = p }
 
-// ── insertBook ──
-// INSERT a new book → returns it with the generated id
 // pg auto-maps columns to object keys — no manual Scan like Go
 export async function insertBook(book: Book): Promise<Book> {
-    const sql: string = `INSERT INTO books (title, author, status) VALUES ($1, $2, $3) RETURNING id, title, author, status`
-    // tells pg the rows coming back are Books objects
+    const sql = `INSERT INTO books (title, author, status) VALUES ($1, $2, $3) RETURNING id, title, author, status`
     const result = await pool.query<Book>(sql, [book.title, book.author, book.status])
     return result.rows[0]
 }
 
-// ── getAllBooks ──
-// SELECT all books → returns the full array
 // no defer rows.Close() needed — pg handles cleanup automatically
 export async function getAllBooks(): Promise<Book[]> {
-    const sql: string = `SELECT id, title, author, status FROM books`
-    // each row is a Book
+    const sql = `SELECT id, title, author, status FROM books`
     const results = await pool.query<Book>(sql)
     return results.rows
 }
 
-// ── getBookById ──
-// SELECT one book by id → returns the book, or undefined if not found
 export async function getBookById(id: number): Promise<Book | undefined> {
     const sql = `SELECT id, title, author, status FROM books WHERE id = $1`
     const result = await pool.query<Book>(sql, [id])
     return result.rows[0]
 }
 
-// ── updateBook ──
-// UPDATE a book's fields by id → returns updated book, or undefined if not found
 // same pattern as insertBook — RETURNING gives back the row in one trip
 export async function updateBook(id: number, book: Book): Promise<Book | undefined> {
-    // SQL: UPDATE books SET title=$1, author=$2, status=$3 WHERE id=$4 RETURNING id, title, author, status
-    // pool.query with [book.title, book.author, book.status, id]
-    // return result.rows[0]
+    const sql = `UPDATE books SET title=$1, author=$2, status=$3 WHERE id=$4 RETURNING id, title, author, status`
+    const result = await pool.query<Book>(sql, [book.title, book.author, book.status, id])
+    return result.rows[0]
 }
 
-// ── deleteBook ──
-// DELETE a book by id → returns true if deleted, false if it didn't exist
 // no RETURNING — nothing comes back, just check rowCount (like Go's RowsAffected)
 export async function deleteBook(id: number): Promise<boolean> {
     const sql = `DELETE FROM books WHERE id = $1`

--- a/ts-bookshelf/src/db.ts
+++ b/ts-bookshelf/src/db.ts
@@ -1,0 +1,66 @@
+// db.ts — Translator layer. Speaks SQL to Postgres and converts
+// the results into TypeScript objects. All database queries live here.
+// Equivalent of db.go in Go.
+
+// ── imports ──
+// Pool from pg — manages database connections
+// Book from models — the type we return
+
+import {Pool} from "pg"
+import {Book} from './models'
+
+// ── pool ──
+// shared database connection — equivalent of Go's `var db *sql.DB`
+// why export? TS files are isolated — index.ts imports pool to set it up,
+// after that only db.ts touches it.
+
+export let pool: Pool
+
+// ── insertBook ──
+// INSERT a new book → returns it with the generated id
+// pg auto-maps columns to object keys — no manual Scan like Go
+export async function insertBook(book: Book): Promise<Book> {
+    const sql: string = `INSERT INTO books (title, author, status) VALUES ($1, $2, $3) RETURNING id, title, author, status`
+    // tells pg the rows coming back are Books objects
+    const result = await pool.query<Book>(sql, [book.title, book.author, book.status])
+    return result.rows[0]
+}
+
+// ── getAllBooks ──
+// SELECT all books → returns the full array
+// no defer rows.Close() needed — pg handles cleanup automatically
+export async function getAllBooks(): Promise<Book[]> {
+    const sql: string = `SELECT id, title, author, status FROM books`
+    // each row is a Book
+    const results = await pool.query<Book>(sql)
+    return results.rows
+}
+
+// ── getBookById ──
+// SELECT one book by id → returns the book, or undefined if not found
+export async function getBookById(id: number): Promise<Book | undefined> {
+    const sql = `SELECT id, title, author, status FROM books WHERE id = $1`
+    const result = await pool.query<Book>(sql, [id])
+    return result.rows[0]
+}
+
+// ── updateBook ──
+// UPDATE a book's fields by id → returns updated book, or undefined if not found
+// same pattern as insertBook — RETURNING gives back the row in one trip
+export async function updateBook(id: number, book: Book): Promise<Book | undefined> {
+    // SQL: UPDATE books SET title=$1, author=$2, status=$3 WHERE id=$4 RETURNING id, title, author, status
+    // pool.query with [book.title, book.author, book.status, id]
+    // return result.rows[0]
+}
+
+// ── deleteBook ──
+// DELETE a book by id → returns true if deleted, false if it didn't exist
+// no RETURNING — nothing comes back, just check rowCount (like Go's RowsAffected)
+export async function deleteBook(id: number): Promise<boolean> {
+    const sql = `DELETE FROM books WHERE id = $1`
+    const result = await pool.query(sql, [id])
+    if (result.rowCount === null || result.rowCount === 0) {
+        return false
+    }
+    return true
+}

--- a/ts-bookshelf/src/db.ts
+++ b/ts-bookshelf/src/db.ts
@@ -16,6 +16,13 @@ import {Book} from './models'
 
 export let pool: Pool
 
+// setPool — lets index.ts and tests assign the pool from outside
+// why not just `export let pool` and reassign it from another file?
+// ES modules give you a copy of the reference, not direct access to the original.
+// reassigning from the importing file only updates your copy — db.ts's pool stays undefined.
+// setter function writes to the original variable inside db.ts.
+export function setPool(p: Pool) { pool = p }
+
 // ── insertBook ──
 // INSERT a new book → returns it with the generated id
 // pg auto-maps columns to object keys — no manual Scan like Go

--- a/ts-bookshelf/src/handlers.ts
+++ b/ts-bookshelf/src/handlers.ts
@@ -1,69 +1,72 @@
-// handlers.ts — Logic layer. One function per CRUD operation.
-// Receives HTTP requests, talks to the DB layer, sends responses.
-// Equivalent of handlers.go in Go.
-//
-// Pattern: read from user → validate → talk to DB → write back to user
-//
-// Rule: every handler must return exactly one response.
-// Error path? → return c.text("error", statusCode)
-// Happy path? → return c.json(data, statusCode)
-//
-//   Handler      | Input         | DB call       | Response
-//   -------------|---------------|---------------|----------
-//   createBook   | JSON body     | insertBook    | 201 + book
-//   getBooks     | nothing       | getAllBooks    | 200 + list
-//   getBook      | id from URL   | getBookById   | 200 + book
-//   updateBook   | id + JSON     | updateBook    | 200 + book
-//   deleteBook   | id from URL   | deleteBook    | 204
+// handlers.ts — Logic layer. read → validate → db → respond.
+// Context (c) = request + response in one object (Go splits these into r and w)
+// c.req.json() / c.req.param("id") to read, c.json() / c.text() to respond
 
 import type { Context } from "hono"
 import { insertBook, getAllBooks, getBookById, updateBook, deleteBook } from "./db"
 import { VALID_STATUSES, STATUS_WANT_TO_READ } from "./models"
 
-// ── createBook ── POST /books
-// read JSON body → validate title+author → validate status → call insertBook → 201
-export async function createBook(c: Context) {
-    // const body = await c.req.json()
-    // validate: if (!body.title || !body.author) → 400
-    // validate: status must be in VALID_STATUSES, default to STATUS_WANT_TO_READ
-    // const book = await insertBook(body)
-    // return c.json(book, 201)
+// POST /books — body → validate title+author → validate status → insertBook → 201
+export async function createBook(c: Context): Promise<Response> {
+    const body = await c.req.json()
+    if (!body.title || !body.author) {
+        return c.text("title and author are required", 400)
+    }
+    if (!body.status) {
+        body.status = STATUS_WANT_TO_READ
+    } else if (!VALID_STATUSES.includes(body.status)) {
+        return c.text("invalid status", 400)
+    }
+    const book = await insertBook(body)
+    return c.json(book, 201)
 }
 
-// ── getBooks ── GET /books
-// no input → call getAllBooks → 200
-export async function getBooks(c: Context) {
-    // const books = await getAllBooks()
-    // return c.json(books, 200)
+// GET /books — getAllBooks → 200
+// pure wrapper
+export async function getBooks(c: Context): Promise<Response> {
+    const books = await getAllBooks()
+    return c.json(books, 200)
 }
 
-// ── getBook ── GET /books/:id
-// parse id from URL → call getBookById → 200 or 404
-export async function getBook(c: Context) {
-    // const id = Number(c.req.param("id"))
-    // if (isNaN(id)) → 400
-    // const book = await getBookById(id)
-    // if (!book) → 404
-    // return c.json(book, 200)
+// GET /books/:id — parse id → getBookById → 200 or 404
+export async function getBook(c: Context): Promise<Response> {
+    const raw = c.req.param("id")   // URL param is always a string
+    const id = Number(raw)           // convert to number
+    if (isNaN(id)) {
+        return c.text("invalid id", 400)
+    }
+    const book = await getBookById(id)
+    if (!book) {
+        return c.text("book not found", 404)
+    }
+    return c.json(book, 200)
 }
 
-// ── updateBook ── PUT /books/:id
-// parse id + JSON body → call updateBook → 200 or 400
-export async function handleUpdateBook(c: Context) {
-    // const id = Number(c.req.param("id"))
-    // if (isNaN(id)) → 400
-    // const body = await c.req.json()
-    // const book = await updateBook(id, body)
-    // if (!book) → 400
-    // return c.json(book, 200)
+// PUT /books/:id — parse id + body → updateBook → 200 or 400
+export async function handleUpdateBook(c: Context): Promise<Response> {
+    const raw = c.req.param("id")
+    const id = Number(raw)
+    if (isNaN(id)) {
+        return c.text("invalid id", 400)
+    }
+    const body = await c.req.json()
+    const book = await updateBook(id, body)
+    if (!book) {
+        return c.text("can't update book", 400)
+    }
+    return c.json(book, 200)
 }
 
-// ── deleteBook ── DELETE /books/:id
-// parse id from URL → call deleteBook → 204 or 404
-export async function handleDeleteBook(c: Context) {
-    // const id = Number(c.req.param("id"))
-    // if (isNaN(id)) → 400
-    // const deleted = await deleteBook(id)
-    // if (!deleted) → 404
-    // return c.body(null, 204)
+// DELETE /books/:id — parse id → deleteBook → 204 or 404
+export async function handleDeleteBook(c: Context): Promise<Response> {
+    const raw = c.req.param("id")
+    const id = Number(raw)
+    if (isNaN(id)) {
+        return c.text("invalid id", 400)
+    }
+    const deleted = await deleteBook(id)
+    if (!deleted) {
+        return c.text("book not found", 404)
+    }
+    return c.body(null, 204)
 }

--- a/ts-bookshelf/src/handlers.ts
+++ b/ts-bookshelf/src/handlers.ts
@@ -1,0 +1,69 @@
+// handlers.ts — Logic layer. One function per CRUD operation.
+// Receives HTTP requests, talks to the DB layer, sends responses.
+// Equivalent of handlers.go in Go.
+//
+// Pattern: read from user → validate → talk to DB → write back to user
+//
+// Rule: every handler must return exactly one response.
+// Error path? → return c.text("error", statusCode)
+// Happy path? → return c.json(data, statusCode)
+//
+//   Handler      | Input         | DB call       | Response
+//   -------------|---------------|---------------|----------
+//   createBook   | JSON body     | insertBook    | 201 + book
+//   getBooks     | nothing       | getAllBooks    | 200 + list
+//   getBook      | id from URL   | getBookById   | 200 + book
+//   updateBook   | id + JSON     | updateBook    | 200 + book
+//   deleteBook   | id from URL   | deleteBook    | 204
+
+import type { Context } from "hono"
+import { insertBook, getAllBooks, getBookById, updateBook, deleteBook } from "./db"
+import { VALID_STATUSES, STATUS_WANT_TO_READ } from "./models"
+
+// ── createBook ── POST /books
+// read JSON body → validate title+author → validate status → call insertBook → 201
+export async function createBook(c: Context) {
+    // const body = await c.req.json()
+    // validate: if (!body.title || !body.author) → 400
+    // validate: status must be in VALID_STATUSES, default to STATUS_WANT_TO_READ
+    // const book = await insertBook(body)
+    // return c.json(book, 201)
+}
+
+// ── getBooks ── GET /books
+// no input → call getAllBooks → 200
+export async function getBooks(c: Context) {
+    // const books = await getAllBooks()
+    // return c.json(books, 200)
+}
+
+// ── getBook ── GET /books/:id
+// parse id from URL → call getBookById → 200 or 404
+export async function getBook(c: Context) {
+    // const id = Number(c.req.param("id"))
+    // if (isNaN(id)) → 400
+    // const book = await getBookById(id)
+    // if (!book) → 404
+    // return c.json(book, 200)
+}
+
+// ── updateBook ── PUT /books/:id
+// parse id + JSON body → call updateBook → 200 or 400
+export async function handleUpdateBook(c: Context) {
+    // const id = Number(c.req.param("id"))
+    // if (isNaN(id)) → 400
+    // const body = await c.req.json()
+    // const book = await updateBook(id, body)
+    // if (!book) → 400
+    // return c.json(book, 200)
+}
+
+// ── deleteBook ── DELETE /books/:id
+// parse id from URL → call deleteBook → 204 or 404
+export async function handleDeleteBook(c: Context) {
+    // const id = Number(c.req.param("id"))
+    // if (isNaN(id)) → 400
+    // const deleted = await deleteBook(id)
+    // if (!deleted) → 404
+    // return c.body(null, 204)
+}

--- a/ts-bookshelf/src/index.ts
+++ b/ts-bookshelf/src/index.ts
@@ -1,0 +1,17 @@
+// index.ts — Entry point. Connects to Postgres, starts the server.
+// Equivalent of main() in Go's main.go.
+//
+// 1. Read DATABASE_URL from environment
+// 2. Initialize the pg Pool (imported from db.ts)
+// 3. Test connection with pool.query("SELECT 1")
+// 4. Start server on port 8081 using Bun.serve
+
+// import { Pool } from "pg"
+// import { pool } from "./db"      — to assign the connection
+// import app from "./routes"        — the Hono app with all routes wired
+
+// read DATABASE_URL
+// create new Pool({ connectionString: databaseUrl })
+// assign to db.ts's exported pool
+// test connection: await pool.query("SELECT 1")
+// start: export default { port: 8081, fetch: app.fetch }

--- a/ts-bookshelf/src/index.ts
+++ b/ts-bookshelf/src/index.ts
@@ -1,17 +1,20 @@
 // index.ts — Entry point. Connects to Postgres, starts the server.
-// Equivalent of main() in Go's main.go.
-//
-// 1. Read DATABASE_URL from environment
-// 2. Initialize the pg Pool (imported from db.ts)
-// 3. Test connection with pool.query("SELECT 1")
-// 4. Start server on port 8081 using Bun.serve
 
-// import { Pool } from "pg"
-// import { pool } from "./db"      — to assign the connection
-// import app from "./routes"        — the Hono app with all routes wired
+import { Pool } from "pg"
+import { pool, setPool } from "./db"
+import app from "./routes"
 
-// read DATABASE_URL
-// create new Pool({ connectionString: databaseUrl })
-// assign to db.ts's exported pool
-// test connection: await pool.query("SELECT 1")
-// start: export default { port: 8081, fetch: app.fetch }
+// create pool needs dbUrl -> only index can
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl){
+    console.error("DATABASE_URL is required")
+    process.exit(1)
+}
+
+// db.ts has the parking spot, index.ts buys the car and parks it.
+// db.ts just drives (pool.query). only index.ts and tests know the connection string.
+setPool(new Pool({ connectionString: databaseUrl }))
+await pool.query("SELECT 1")
+console.log("connected to database")
+
+export default { port: 8081, fetch: app.fetch }

--- a/ts-bookshelf/src/models.ts
+++ b/ts-bookshelf/src/models.ts
@@ -1,0 +1,19 @@
+// models.ts — Defines the Book type and status constants.
+// Shared across all layers. Equivalent of models.go in Go.
+//
+// TypeScript advantage: union types catch invalid status at compile time.
+// Go uses string constants — typos only caught at runtime.
+
+export type BookStatus = "want to read" | "reading" | "finished";
+
+export const STATUS_WANT_TO_READ: BookStatus = "want to read";
+export const STATUS_READING: BookStatus = "reading";
+export const STATUS_FINISHED: BookStatus = "finished";
+export const VALID_STATUSES: BookStatus[] = [STATUS_WANT_TO_READ, STATUS_READING, STATUS_FINISHED];
+
+export interface Book {
+  id: number;
+  title: string;
+  author: string;
+  status: BookStatus;
+}

--- a/ts-bookshelf/src/routes.ts
+++ b/ts-bookshelf/src/routes.ts
@@ -1,0 +1,18 @@
+// routes.ts — Route mapping. Which URL goes to which handler.
+// Equivalent of setupRouter() in Go's main.go.
+//
+// Separated from index.ts so tests can import the app
+// without booting the server.
+
+import { Hono } from "hono"
+import { createBook, getBooks, getBook, handleUpdateBook, handleDeleteBook } from "./handlers"
+
+const app = new Hono()
+
+// POST   /books      → createBook
+// GET    /books      → getBooks
+// GET    /books/:id  → getBook       (:id not {id} like Go)
+// PUT    /books/:id  → handleUpdateBook
+// DELETE /books/:id  → handleDeleteBook
+
+export default app

--- a/ts-bookshelf/src/routes.ts
+++ b/ts-bookshelf/src/routes.ts
@@ -1,18 +1,17 @@
 // routes.ts — Route mapping. Which URL goes to which handler.
-// Equivalent of setupRouter() in Go's main.go.
-//
-// Separated from index.ts so tests can import the app
-// without booting the server.
+// Separated from index.ts so tests can import the app without booting the server.
 
 import { Hono } from "hono"
 import { createBook, getBooks, getBook, handleUpdateBook, handleDeleteBook } from "./handlers"
 
 const app = new Hono()
 
-// POST   /books      → createBook
-// GET    /books      → getBooks
-// GET    /books/:id  → getBook       (:id not {id} like Go)
-// PUT    /books/:id  → handleUpdateBook
-// DELETE /books/:id  → handleDeleteBook
+// /books     → create, list
+// /books/:id → get, update, delete
+app.post("/books", createBook)
+app.get("/books", getBooks)
+app.get("/books/:id", getBook)
+app.put("/books/:id", handleUpdateBook)
+app.delete("/books/:id", handleDeleteBook)
 
 export default app

--- a/ts-bookshelf/test/handlers.test.ts
+++ b/ts-bookshelf/test/handlers.test.ts
@@ -1,41 +1,46 @@
 // handlers.test.ts — Integration tests. Same 8 tests as Go.
 // Sends requests through Hono → handler → db → Postgres.
+//
+// Go tests hardcoded /books/1 — worked because Go ran on a fresh DB.
+// Shared DB means IDs are unpredictable, so we capture the id from create
+// and use it in get/update/delete.
 
 import { describe, test, expect } from "bun:test"
 import "./helpers"
 import { sendAndExpect } from "./helpers"
 
+// shared across tests — set by create, used by get/update/delete
+let bookId: number
+
 describe("books", () => {
 
-    // POST /books — create a book, check fields + id assigned
+    // POST /books — create a book, capture its id for later tests
     test("create book", async () => {
         const res = await sendAndExpect("POST", "/books", { title: "Dune", author: "Frank Herbert"}, 201)
-        // response object has json() built in
         const body = await res.json()
 
         expect(body.title).toBe("Dune")
         expect(body.author).toBe("Frank Herbert")
         expect(body.status).toBe("want to read")
         expect(body.id).toBeGreaterThan(0)
+
+        bookId = body.id
     })
 
     // GET /books — list all, check non-empty
     test("get books", async () => {
-        // parse body, expect array length > 0
         const res = await sendAndExpect("GET", "/books", undefined, 200)
         const body = await res.json()
 
         expect(body.length).toBeGreaterThan(0)
     })
 
-    // GET /books/1 — get one, check fields exist
+    // GET /books/:id — get the book we created
     test("get book", async () => {
-        // sendAndExpect("GET", "/books/1", undefined, 200)
-        // parse body, expect id, title, author, status all present
-        const res = await sendAndExpect("GET", "/books/1", undefined, 200)
+        const res = await sendAndExpect("GET", `/books/${bookId}`, undefined, 200)
         const body = await res.json()
 
-        expect(body.id).toBeGreaterThan(0)
+        expect(body.id).toBe(bookId)
         expect(body.title).not.toBeEmpty()
         expect(body.author).not.toBeEmpty()
         expect(body.status).not.toBeEmpty()
@@ -43,21 +48,20 @@ describe("books", () => {
 
     // GET /books/99999 — not found
     test("get book not found", async () => {
-        // no body (ba dum ts) found, just let SAE check status code
         await sendAndExpect("GET", "/books/99999", undefined, 404)
     })
 
-    // PUT /books/1 — update status, check it changed
+    // PUT /books/:id — update the book we created
     test("update book", async () => {
-        const res = await sendAndExpect("PUT", "/books/1", { title: "Dune", author: "Frank Herbert", status: "reading" }, 200)
+        const res = await sendAndExpect("PUT", `/books/${bookId}`, { title: "Dune", author: "Frank Herbert", status: "reading" }, 200)
         const body = await res.json()
 
         expect(body.status).toBe("reading")
     })
 
-    // DELETE /books/1 — delete, check 204
+    // DELETE /books/:id — delete the book we created
     test("delete book", async () => {
-        await sendAndExpect("DELETE", "/books/1", undefined, 204)
+        await sendAndExpect("DELETE", `/books/${bookId}`, undefined, 204)
     })
 
     // POST /books — missing title, check 400

--- a/ts-bookshelf/test/handlers.test.ts
+++ b/ts-bookshelf/test/handlers.test.ts
@@ -1,0 +1,72 @@
+// handlers.test.ts — Integration tests. Same 8 tests as Go.
+// Sends requests through Hono → handler → db → Postgres.
+
+import { describe, test, expect } from "bun:test"
+import "./helpers"
+import { sendAndExpect } from "./helpers"
+
+describe("books", () => {
+
+    // POST /books — create a book, check fields + id assigned
+    test("create book", async () => {
+        const res = await sendAndExpect("POST", "/books", { title: "Dune", author: "Frank Herbert"}, 201)
+        // response object has json() built in
+        const body = await res.json()
+
+        expect(body.title).toBe("Dune")
+        expect(body.author).toBe("Frank Herbert")
+        expect(body.status).toBe("want to read")
+        expect(body.id).toBeGreaterThan(0)
+    })
+
+    // GET /books — list all, check non-empty
+    test("get books", async () => {
+        // parse body, expect array length > 0
+        const res = await sendAndExpect("GET", "/books", undefined, 200)
+        const body = await res.json()
+
+        expect(body.length).toBeGreaterThan(0)
+    })
+
+    // GET /books/1 — get one, check fields exist
+    test("get book", async () => {
+        // sendAndExpect("GET", "/books/1", undefined, 200)
+        // parse body, expect id, title, author, status all present
+        const res = await sendAndExpect("GET", "/books/1", undefined, 200)
+        const body = await res.json()
+
+        expect(body.id).toBeGreaterThan(0)
+        expect(body.title).not.toBeEmpty()
+        expect(body.author).not.toBeEmpty()
+        expect(body.status).not.toBeEmpty()
+    })
+
+    // GET /books/99999 — not found
+    test("get book not found", async () => {
+        // no body (ba dum ts) found, just let SAE check status code
+        await sendAndExpect("GET", "/books/99999", undefined, 404)
+    })
+
+    // PUT /books/1 — update status, check it changed
+    test("update book", async () => {
+        const res = await sendAndExpect("PUT", "/books/1", { title: "Dune", author: "Frank Herbert", status: "reading" }, 200)
+        const body = await res.json()
+
+        expect(body.status).toBe("reading")
+    })
+
+    // DELETE /books/1 — delete, check 204
+    test("delete book", async () => {
+        await sendAndExpect("DELETE", "/books/1", undefined, 204)
+    })
+
+    // POST /books — missing title, check 400
+    test("create book no title", async () => {
+        await sendAndExpect("POST", "/books", { author: "Frank Herbert" }, 400)
+    })
+
+    // POST /books — invalid status, check 400
+    test("create book invalid status", async () => {
+        await sendAndExpect("POST", "/books", { title: "Dune", author: "Frank Herbert", status: "burned" }, 400)
+    })
+})

--- a/ts-bookshelf/test/helpers.ts
+++ b/ts-bookshelf/test/helpers.ts
@@ -1,0 +1,37 @@
+// helpers.ts — Reusable functions for tests.
+// Go uses TestMain, Bun uses beforeAll/afterAll — same idea.
+
+import { beforeAll, afterAll, expect } from "bun:test"
+import { Pool } from "pg"
+import { pool, setPool } from "../src/db"
+import app from "../src/routes"
+
+// ── setup — connect to Postgres before tests ──
+beforeAll(async() => {
+    // connectionString is shortcut for { host, port, user, ... } — matches DATABASE_URL format
+    const databaseUrl = process.env.DATABASE_URL || "postgres://shelf:shelf@db:5432/bookshelf?sslmode=disable"
+    const p = new Pool({ connectionString: databaseUrl })
+    // can't import pool directly and reassign — ES modules give you a copy, not the original
+    setPool(p)
+})
+
+// ── teardown — close pool after tests ──
+afterAll(async() => {
+    await pool.end()
+})
+
+// ── sendRequest — wraps app.request(), returns Response ──
+export async function sendRequest(method: string, url: string, body?: object): Promise<Response> {
+    return await app.request(url, {
+        method: method,
+        body: body ? JSON.stringify(body) : undefined,
+        headers: {"Content-Type": "application/json"}
+    })
+}
+
+// ── sendAndExpect — sendRequest + assert status code ──
+export async function sendAndExpect(method: string, url: string, body: object | undefined, expectedStatus: number): Promise<Response>{
+    const result = await sendRequest(method, url, body)
+    expect(result.status).toBe(expectedStatus)
+    return result
+}

--- a/ts-bookshelf/tsconfig.json
+++ b/ts-bookshelf/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun-types"],
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "./dist"
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- Full CRUD bookshelf in TypeScript using Bun + Hono + pg
- Same API contract as Go implementation, runs on port 8081
- All 8 integration tests passing against shared Postgres
- Docker Compose updated to run both services simultaneously

## Stack
Bun (runtime) + Hono (router) + pg (raw SQL) + Bun test runner

## Files
```
ts-bookshelf/
├── src/
│   ├── index.ts        # entry point
│   ├── routes.ts       # Hono route mappings
│   ├── handlers.ts     # CRUD logic
│   ├── db.ts           # raw SQL queries
│   └── models.ts       # Book interface + status types
├── test/
│   ├── helpers.ts      # beforeAll/afterAll + request helpers
│   └── handlers.test.ts
├── Dockerfile
├── .devcontainer/
├── package.json
└── tsconfig.json
```

## Test plan
- [x] All 8 tests pass (`bun test` inside container)
- [x] Both Go and TS services run simultaneously via `docker compose up`
- [x] Tests use dynamic IDs (not hardcoded) for shared DB compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)