### PR TITLE
feat(gleam): define Book type and BookStatus custom type

### DIFF
--- a/.github/workflows/gleam.yml
+++ b/.github/workflows/gleam.yml
@@ -1,0 +1,31 @@
+name: Gleam
+
+on:
+  push:
+    paths: [gleam-bookshelf/**]
+  pull_request:
+    paths: [gleam-bookshelf/**]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          gleam-version: "1.14.0"
+
+      - name: Download deps
+        working-directory: gleam-bookshelf
+        run: gleam deps download
+
+      - name: Build
+        working-directory: gleam-bookshelf
+        run: gleam build
+
+      - name: Format check
+        working-directory: gleam-bookshelf
+        run: gleam format --check src/

--- a/.github/workflows/gleam.yml
+++ b/.github/workflows/gleam.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           otp-version: "27"
           gleam-version: "1.14.0"
+          rebar3-version: "3"
 
       - name: Download deps
         working-directory: gleam-bookshelf

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,44 @@
+name: Go
+
+on:
+  push:
+    paths: [go-bookshelf/**]
+  pull_request:
+    paths: [go-bookshelf/**]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: shelf
+          POSTGRES_PASSWORD: shelf
+          POSTGRES_DB: bookshelf
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U shelf -d bookshelf"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 10
+        volumes:
+          - ${{ github.workspace }}/db/init.sql:/docker-entrypoint-initdb.d/init.sql
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Build
+        working-directory: go-bookshelf
+        run: go build ./...
+
+      - name: Test
+        working-directory: go-bookshelf
+        env:
+          DATABASE_URL: postgres://shelf:shelf@localhost:5432/bookshelf?sslmode=disable
+        run: go test ./...

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -1,0 +1,42 @@
+name: TypeScript
+
+on:
+  push:
+    paths: [ts-bookshelf/**]
+  pull_request:
+    paths: [ts-bookshelf/**]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: shelf
+          POSTGRES_PASSWORD: shelf
+          POSTGRES_DB: bookshelf
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U shelf -d bookshelf"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 10
+        volumes:
+          - ${{ github.workspace }}/db/init.sql:/docker-entrypoint-initdb.d/init.sql
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install
+        working-directory: ts-bookshelf
+        run: bun install
+
+      - name: Test
+        working-directory: ts-bookshelf
+        env:
+          DATABASE_URL: postgres://shelf:shelf@localhost:5432/bookshelf?sslmode=disable
+        run: bun test

--- a/gleam-bookshelf/src/models.gleam
+++ b/gleam-bookshelf/src/models.gleam
@@ -1,0 +1,44 @@
+// models.gleam — Defines the Book type and BookStatus custom type.
+// Shared across all layers. Equivalent of models.go and models.ts.
+//
+// Go uses string constants — typos only caught at runtime.
+// TypeScript uses union types — caught at compile time.
+// Gleam uses custom types — caught at compile time + exhaustive matching.
+
+/// The three allowed reading statuses.
+/// Unlike Go/TS where these are just strings, Gleam makes them
+/// their own type — the compiler rejects anything else.
+pub type BookStatus {
+  WantToRead
+  Reading
+  Finished
+}
+
+/// A book on the shelf. Immutable — once created, never changed.
+/// To "update" a field, you create a new Book with the changed value.
+pub type Book {
+  Book(id: Int, title: String, author: String, status: BookStatus)
+}
+
+/// Convert a BookStatus to the string the database stores.
+/// Pattern matching guarantees every variant is handled —
+/// if you add a new status, this won't compile until you add a case.
+pub fn status_to_string(status: BookStatus) -> String {
+  case status {
+    WantToRead -> "want to read"
+    Reading -> "reading"
+    Finished -> "finished"
+  }
+}
+
+/// Convert a database string back to a BookStatus.
+/// Returns Result because the string might be invalid —
+/// Go would return (status, error), TS would throw, Gleam returns Result.
+pub fn status_from_string(s: String) -> Result(BookStatus, Nil) {
+  case s {
+    "want to read" -> Ok(WantToRead)
+    "reading" -> Ok(Reading)
+    "finished" -> Ok(Finished)
+    _ -> Error(Nil)
+  }
+}


### PR DESCRIPTION
## Summary
- Added `models.gleam` with `BookStatus` custom type and `Book` record type
- `status_to_string` / `status_from_string` converters for DB serialization
- Compiler-enforced exhaustive matching — no invalid status can slip through

## Comparison
| | Go | TypeScript | Gleam |
|---|---|---|---|
| Status type | `string` constants | Union type `"reading" \| ...` | Custom type `Reading` |
| Invalid status caught at | Runtime | Compile time | Compile time + exhaustive match |
| Converter needed? | No (already strings) | No (already strings) | Yes (`status_to_string` / `status_from_string`) |

## Test plan
- [x] `gleam build` compiles with no warnings

Closes #8